### PR TITLE
[chore][BE] 환경별 설정 분리 및 하드코딩 제거

### DIFF
--- a/BE/.sdkmanrc
+++ b/BE/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=21.0.6-zulu

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -9,6 +9,7 @@ import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.model.UrlAccessLog;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +30,9 @@ public class ShortUrlController {
 	private final CreateShortUrlUseCase createShortUrlUseCase;
 	private final ResolveUrlUseCase resolveUrlUseCase;
 	private final GetStatsUseCase getStatsUseCase;
+	
+	@Value("${server.url}")
+	private String serverUrl;
 
 	@PostMapping("/urls")
 	public ResponseEntity<CreateShortUrlResponse> createShortUrl(@Valid @RequestBody CreateShortUrlRequest request) {
@@ -36,7 +40,7 @@ public class ShortUrlController {
 		
 		CreateShortUrlResponse response = new CreateShortUrlResponse(
 				shortUrl.code(),
-				"http://localhost:8080/api/v1/r/" + shortUrl.code()
+				serverUrl + "/api/v1/r/" + shortUrl.code()
 		);
 		
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/BE/src/main/resources/application-dev.yaml
+++ b/BE/src/main/resources/application-dev.yaml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:shortlink
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+server:
+  url: ${SERVER_URL:http://localhost:8080}
+  port: 8080
+
+logging:
+  level:
+    io.github.columnwise.shortlink: DEBUG
+    org.springframework.data.redis: DEBUG

--- a/BE/src/main/resources/application-dev.yaml
+++ b/BE/src/main/resources/application-dev.yaml
@@ -14,6 +14,7 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    open-in-view: false
     properties:
       hibernate:
         format_sql: true

--- a/BE/src/main/resources/application-prod.yaml
+++ b/BE/src/main/resources/application-prod.yaml
@@ -1,0 +1,36 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:shortlink_prod}?useSSL=true&requireSSL=true&serverTimezone=UTC
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DB_USERNAME:shortlink}
+    password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+
+server:
+  url: ${SERVER_URL:https://shortlink.example.com}
+  port: 8080
+
+logging:
+  level:
+    io.github.columnwise.shortlink: WARN
+    org.springframework.data.redis: ERROR

--- a/BE/src/main/resources/application-prod.yaml
+++ b/BE/src/main/resources/application-prod.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:shortlink_prod}?useSSL=true&requireSSL=true&serverTimezone=UTC
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:shortlink_prod}?sslMode=REQUIRED&enabledTLSProtocols=TLSv1.2,TLSv1.3&serverTimezone=UTC
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME:shortlink}
     password: ${DB_PASSWORD}
@@ -15,6 +15,7 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect

--- a/BE/src/main/resources/application.yaml
+++ b/BE/src/main/resources/application.yaml
@@ -4,5 +4,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+server:
+  url: ${SERVER_URL:http://localhost:8080}


### PR DESCRIPTION
  ## 📌 PR 개요
  localhost 하드코딩을 제거하고 dev/prod 환경별 설정을 분리하여 배포 환경 유연성 확보

  ## 🔍 변경 내용
  - `application.yaml`의 Redis localhost 설정을 환경변수 기반으로 변경 (`${REDIS_HOST:localhost}`)
  - `ShortUrlController`의 하드코딩된 도메인 URL을 `@Value("${server.url}")` 주입으로 변경
  - `application-dev.yaml` 추가: H2 개발 환경 설정
  - `application-prod.yaml` 추가: MySQL 운영 환경 설정
  - `build.gradle`에 MySQL 드라이버 의존성 추가 (`mysql-connector-j`)

  ## 🗂 관련 이슈
  - close #21 localhost 하드코딩 제거
  - close #22 환경별 설정 분리

  ## 💡 테스트 방법
  1. 빌드 테스트: `./gradlew build` (✅ 통과 확인됨)
  2. 개발 환경 실행: `./gradlew bootRun --args='--spring.profiles.active=dev'`
  3. 환경변수 테스트: `REDIS_HOST=redis-server ./gradlew bootRun`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 프로덕션에서 MySQL 사용을 지원합니다.
  - 단축 URL 응답의 베이스 URL을 환경 변수로 설정할 수 있습니다.

- 설정
  - 개발 프로필에 H2 인메모리 DB와 H2 콘솔을 추가했습니다.
  - Redis 연결(호스트/포트/비밀번호)을 환경 변수로 구성할 수 있습니다.
  - 서버 URL/포트를 환경 변수로 제어할 수 있습니다.
  - 프로덕션에 커넥션 풀 및 Hibernate 검증 설정을 적용했습니다.

- 잡무
  - 개발 환경의 Java 버전을 고정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->