### PR TITLE
[docs][BE] SpringDoc OpenAPI 3 API 문서화 추가

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -7,6 +7,13 @@ import io.github.columnwise.shortlink.application.port.in.GetStatsUseCase;
 import io.github.columnwise.shortlink.application.port.in.ResolveUrlUseCase;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.model.UrlAccessLog;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +32,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "Short URL API", description = "URL 단축 서비스 REST API")
 public class ShortUrlController {
 
 	private final CreateShortUrlUseCase createShortUrlUseCase;
@@ -35,7 +43,25 @@ public class ShortUrlController {
 	private String serverUrl;
 
 	@PostMapping("/urls")
-	public ResponseEntity<CreateShortUrlResponse> createShortUrl(@Valid @RequestBody CreateShortUrlRequest request) {
+	@Operation(
+		summary = "URL 단축",
+		description = "긴 URL을 단축 코드로 변환합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "201",
+			description = "URL 단축 성공",
+			content = @Content(schema = @Schema(implementation = CreateShortUrlResponse.class))
+		),
+		@ApiResponse(
+			responseCode = "400",
+			description = "잘못된 요청 (유효하지 않은 URL 형식)"
+		)
+	})
+	public ResponseEntity<CreateShortUrlResponse> createShortUrl(
+		@Parameter(description = "단축할 URL 정보", required = true)
+		@Valid @RequestBody CreateShortUrlRequest request
+	) {
 		ShortUrl shortUrl = createShortUrlUseCase.createShortUrl(request.longUrl());
 		
 		CreateShortUrlResponse response = new CreateShortUrlResponse(
@@ -47,13 +73,48 @@ public class ShortUrlController {
 	}
 
 	@GetMapping("/r/{code}")
-	public RedirectView redirectToOriginalUrl(@PathVariable("code") String code) {
+	@Operation(
+		summary = "URL 리다이렉트",
+		description = "단축 코드를 통해 원본 URL로 리다이렉트합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "302",
+			description = "원본 URL로 리다이렉트 성공"
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "존재하지 않는 단축 코드"
+		)
+	})
+	public RedirectView redirectToOriginalUrl(
+		@Parameter(description = "단축 코드", required = true, example = "abc123")
+		@PathVariable("code") String code
+	) {
 		String longUrl = resolveUrlUseCase.resolveUrl(code);
 		return new RedirectView(longUrl);
 	}
 
 	@GetMapping("/urls/{code}/stats")
-	public ResponseEntity<List<UrlAccessLog>> getAccessLogs(@PathVariable("code") String code) {
+	@Operation(
+		summary = "URL 접속 통계 조회",
+		description = "특정 단축 URL의 접속 로그 및 통계 정보를 조회합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "통계 조회 성공",
+			content = @Content(schema = @Schema(implementation = UrlAccessLog.class))
+		),
+		@ApiResponse(
+			responseCode = "404",
+			description = "존재하지 않는 단축 코드"
+		)
+	})
+	public ResponseEntity<List<UrlAccessLog>> getAccessLogs(
+		@Parameter(description = "단축 코드", required = true, example = "abc123")
+		@PathVariable("code") String code
+	) {
 		List<UrlAccessLog> accessLogs = getStatsUseCase.getAccessLogs(code);
 		return ResponseEntity.ok(accessLogs);
 	}

--- a/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/dto/CreateShortUrlRequest.java
+++ b/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/dto/CreateShortUrlRequest.java
@@ -1,8 +1,15 @@
 package io.github.columnwise.shortlink.adapter.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "URL 단축 요청")
 public record CreateShortUrlRequest(
+		@Schema(
+			description = "단축할 원본 URL", 
+			example = "https://www.example.com/very/long/path/to/resource",
+			requiredMode = Schema.RequiredMode.REQUIRED
+		)
 		@NotBlank @Size(max = 2048) String longUrl
 ) {}

--- a/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/dto/CreateShortUrlResponse.java
+++ b/BE/src/main/java/io/github/columnwise/shortlink/adapter/web/dto/CreateShortUrlResponse.java
@@ -1,3 +1,12 @@
 package io.github.columnwise.shortlink.adapter.web.dto;
 
-public record CreateShortUrlResponse(String code, String shortUrl) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "URL 단축 응답")
+public record CreateShortUrlResponse(
+		@Schema(description = "생성된 단축 코드", example = "abc123")
+		String code,
+		
+		@Schema(description = "완성된 단축 URL", example = "http://localhost:8080/api/v1/r/abc123")
+		String shortUrl
+) {}

--- a/BE/src/main/java/io/github/columnwise/shortlink/domain/model/UrlAccessLog.java
+++ b/BE/src/main/java/io/github/columnwise/shortlink/domain/model/UrlAccessLog.java
@@ -1,15 +1,26 @@
 package io.github.columnwise.shortlink.domain.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.Instant;
 
 @Builder
+@Schema(description = "URL 접속 로그")
 public record UrlAccessLog(
+        @Schema(description = "로그 ID", example = "1")
         long id,
+        
+        @Schema(description = "단축 코드", example = "abc123")
         String code,
+        
+        @Schema(description = "접속 IP 주소", example = "192.168.1.1")
         String ipAddress,
+        
+        @Schema(description = "사용자 에이전트", example = "Mozilla/5.0...")
         String userAgent,
+        
+        @Schema(description = "접속 시간", example = "2024-01-01T12:00:00Z")
         Instant accessedAt
 ) {
 }

--- a/BE/src/main/resources/application-prod.yaml
+++ b/BE/src/main/resources/application-prod.yaml
@@ -31,6 +31,12 @@ server:
   url: ${SERVER_URL:https://shortlink.example.com}
   port: 8080
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
 logging:
   level:
     io.github.columnwise.shortlink: WARN


### PR DESCRIPTION
## 📌 PR 개요

  - SpringDoc OpenAPI 3을 활용하여 REST API 자동 문서화 구현

  ## 🔍 변경 내용

  - **build.gradle**: SpringDoc OpenAPI starter 의존성 추가
  - **ShortUrlController**: @Tag, @Operation, @ApiResponse, @Parameter 어노테이션으로 API
  엔드포인트 문서화
  - **CreateShortUrlRequest/Response**: @Schema 어노테이션으로 요청/응답 DTO 필드 문서화
  - **UrlAccessLog**: @Schema 어노테이션으로 도메인 모델 필드 문서화

  ## 🗂 관련 이슈

  - close #13 API 문서화 (SpringDoc 활용)

  ## 💡 테스트 방법

  1. 애플리케이션 실행 (`./gradlew bootRun`)
  2. Swagger UI 접속: `http://localhost:8080/swagger-ui/index.html`
  3. API 문서 확인 및 Try it out 기능으로 API 테스트
  4. OpenAPI JSON 스펙 확인: `http://localhost:8080/v3/api-docs`

  ## 🖼️ 스크린샷/로그 (선택)

  Swagger UI를 통해 다음과 같은 API 문서 확인 가능:
  - URL 단축 API (`POST /api/v1/urls`)
  - URL 리다이렉트 API (`GET /api/v1/r/{code}`)
  - URL 접속 통계 API (`GET /api/v1/urls/{code}/stats`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 개발환경에서 사용 가능한 OpenAPI/Swagger UI 추가(프로덕션 환경에서는 비활성화).

* **Documentation**
  * 전체 단축 URL API에 태그·엔드포인트 설명·응답 코드 문서화(201,302,200,400,404).
  * 요청/응답 스키마에 설명·예시값·필수 여부 추가로 가독성 향상.
  * 경로·본문 파라미터에 설명 추가로 API 이해도 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->