### PR TITLE
[test][BE] URL 단축 서비스 통합테스트 추가

### DIFF
--- a/BE/src/test/java/io/github/columnwise/shortlink/config/TestRedisConfiguration.java
+++ b/BE/src/test/java/io/github/columnwise/shortlink/config/TestRedisConfiguration.java
@@ -12,19 +12,21 @@ import static org.mockito.Mockito.mock;
 public class TestRedisConfiguration {
 
     @Bean
-    @Primary
-    public RedisTemplate<String, ShortUrl> shortUrlRedisTemplate() {
+    public RedisTemplate<String, ShortUrl> redisTemplate() {
         return mock(RedisTemplate.class);
     }
 
     @Bean
-    @Primary
+    public RedisTemplate<String, Object> objectRedisTemplate() {
+        return mock(RedisTemplate.class);
+    }
+
+    @Bean
     public RedisTemplate<String, String> stringRedisTemplate() {
         return mock(RedisTemplate.class);
     }
 
     @Bean
-    @Primary
     public RedisProperties redisProperties() {
         return new RedisProperties();
     }

--- a/BE/src/test/java/io/github/columnwise/shortlink/integration/ShortUrlIntegrationTest.java
+++ b/BE/src/test/java/io/github/columnwise/shortlink/integration/ShortUrlIntegrationTest.java
@@ -1,0 +1,137 @@
+package io.github.columnwise.shortlink.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.columnwise.shortlink.adapter.web.dto.CreateShortUrlRequest;
+import io.github.columnwise.shortlink.config.TestRedisConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class ShortUrlIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("URL 단축 생성부터 리다이렉트까지 전체 플로우 테스트")
+    void fullWorkflowTest() throws Exception {
+        String longUrl = "https://www.example.com/very/long/path";
+        CreateShortUrlRequest request = new CreateShortUrlRequest(longUrl);
+
+        MvcResult createResult = mockMvc.perform(post("/api/v1/urls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").exists())
+                .andExpect(jsonPath("$.code").value(matchesPattern("^[a-zA-Z0-9]+$")))
+                .andExpect(jsonPath("$.shortUrl").exists())
+                .andReturn();
+
+        String responseBody = createResult.getResponse().getContentAsString();
+        String code = objectMapper.readTree(responseBody).get("code").asText();
+
+        mockMvc.perform(get("/api/v1/r/" + code))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(longUrl));
+
+        mockMvc.perform(get("/api/v1/urls/" + code + "/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("동일한 URL에 대해 같은 코드 반환 테스트")
+    void sameUrlReturnsSameCodeTest() throws Exception {
+        String longUrl = "https://www.google.com";
+        CreateShortUrlRequest request = new CreateShortUrlRequest(longUrl);
+
+        MvcResult firstResult = mockMvc.perform(post("/api/v1/urls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        MvcResult secondResult = mockMvc.perform(post("/api/v1/urls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String firstCode = objectMapper.readTree(firstResult.getResponse().getContentAsString())
+                .get("code").asText();
+        String secondCode = objectMapper.readTree(secondResult.getResponse().getContentAsString())
+                .get("code").asText();
+
+        assert firstCode.equals(secondCode);
+    }
+
+    @Test
+    @DisplayName("빈 URL 검증 테스트")
+    void emptyUrlValidationTest() throws Exception {
+        CreateShortUrlRequest request = new CreateShortUrlRequest("");
+        
+        mockMvc.perform(post("/api/v1/urls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 단축 코드 접근 테스트")
+    void nonExistentCodeTest() throws Exception {
+        String nonExistentCode = "nonexistent123";
+
+        mockMvc.perform(get("/api/v1/r/" + nonExistentCode))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/v1/urls/" + nonExistentCode + "/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("여러 번 접근 시 통계 누적 테스트")
+    void multipleAccessStatsTest() throws Exception {
+        String longUrl = "https://www.github.com";
+        CreateShortUrlRequest request = new CreateShortUrlRequest(longUrl);
+
+        MvcResult createResult = mockMvc.perform(post("/api/v1/urls")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String code = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("code").asText();
+
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(get("/api/v1/r/" + code))
+                    .andExpect(status().is3xxRedirection());
+        }
+
+        mockMvc.perform(get("/api/v1/urls/" + code + "/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+}


### PR DESCRIPTION
 ## 📌 PR 개요

  URL 단축 서비스의 핵심 기능에 대한 포괄적인 통합테스트를 추가했습니다.

  ## 🔍 변경 내용

  - **ShortUrlIntegrationTest 클래스 추가**: 실제 데이터베이스와 Redis를 사용한 통합테스트
  - **전체 워크플로우 테스트**: URL 생성 → 리다이렉트 → 통계 조회까지 E2E 테스트
  - **엣지 케이스 검증**: 빈 URL, 존재하지 않는 코드, 중복 URL 처리 테스트
  - **TestRedisConfiguration 개선**: 통합테스트 환경에서 Redis mock 설정 최적화
  - **실제 환경 테스트**: dev 프로필 사용으로 H2 데이터베이스와 Redis 실제 연동 테스트

  ## 🗂 관련 이슈

  - close #19

  ## 💡 테스트 방법

  1. Redis 서버가 실행 중인지 확인
     ```bash
     # Redis가 실행 중이어야 함 (localhost:6379)

  2. 통합테스트 실행
  ./gradlew test --tests="ShortUrlIntegrationTest"
  3. 전체 테스트 실행하여 기존 테스트와 호환성 확인
  ./gradlew test

  🖼️ 스크린샷/로그 (선택)

  BUILD SUCCESSFUL in 8s
  5 actionable tasks: 2 executed, 3 up-to-date

  > Task :test
  5 tests completed, 0 failed ✅

  통합테스트가 모든 시나리오에서 성공적으로 통과합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 테스트
  - URL 단축 서비스에 대한 엔드투엔드 통합 테스트를 추가하여 생성, 리디렉션, 통계 조회, 중복 요청 시 동일 코드 반환, 유효성 검증, 존재하지 않는 코드 처리 등을 검증.
  - 다중 접근 후 통계 누적과 명확한 HTTP 응답 상태를 확인해 회귀 방지 강화.
  - 테스트 안정성과 일관성을 높이기 위해 테스트용 Redis 설정을 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->