### PR TITLE
fix: Resolve failing test cases and improve statistics service valida…

### DIFF
--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/GetStatsService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/GetStatsService.java
@@ -2,6 +2,8 @@ package io.github.columnwise.shortlink.application.service;
 
 import io.github.columnwise.shortlink.application.port.in.GetStatsUseCase;
 import io.github.columnwise.shortlink.application.port.out.StatisticsRepository;
+import io.github.columnwise.shortlink.application.port.out.ShortUrlRepositoryPort;
+import io.github.columnwise.shortlink.domain.exception.UrlNotFoundException;
 import io.github.columnwise.shortlink.domain.model.DailyStatistics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,11 +14,16 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class GetStatsService implements GetStatsUseCase {
-    
+
     private final StatisticsRepository statisticsRepository;
-    
+    private final ShortUrlRepositoryPort shortUrlRepositoryPort;
+
     @Override
     public List<DailyStatistics> getDailyStatistics(String code, LocalDate startDate, LocalDate endDate) {
+        // 먼저 코드가 존재하는지 확인
+        shortUrlRepositoryPort.findByCode(code)
+            .orElseThrow(() -> new UrlNotFoundException("URL not found for code: " + code));
+
         // 기본값 설정
         if (endDate == null) {
             endDate = LocalDate.now();
@@ -24,7 +31,7 @@ public class GetStatsService implements GetStatsUseCase {
         if (startDate == null) {
             startDate = endDate.minusDays(30);  // 기본 30일
         }
-        
+
         return statisticsRepository.getDailyStatistics(code, startDate, endDate);
     }
 }

--- a/BE/api-server/src/test/java/io/github/columnwise/shortlink/adapter/web/ShortUrlControllerTest.java
+++ b/BE/api-server/src/test/java/io/github/columnwise/shortlink/adapter/web/ShortUrlControllerTest.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -129,7 +130,7 @@ class ShortUrlControllerTest {
                         .build()
         );
 
-        when(getStatsUseCase.getDailyStatistics(eq(code), eq(null), eq(null))).thenReturn(mockStats);
+        when(getStatsUseCase.getDailyStatistics(eq(code), any(LocalDate.class), any(LocalDate.class))).thenReturn(mockStats);
 
         // When & Then
         mockMvc.perform(get("/api/v1/urls/" + code + "/stats"))
@@ -146,7 +147,7 @@ class ShortUrlControllerTest {
         // Given
         String code = "notfound";
 
-        when(getStatsUseCase.getDailyStatistics(eq(code), eq(null), eq(null)))
+        when(getStatsUseCase.getDailyStatistics(eq(code), any(LocalDate.class), any(LocalDate.class)))
                 .thenThrow(new UrlNotFoundException("URL not found for code: " + code));
 
         // When & Then

--- a/BE/api-server/src/test/java/io/github/columnwise/shortlink/integration/ShortUrlIntegrationTest.java
+++ b/BE/api-server/src/test/java/io/github/columnwise/shortlink/integration/ShortUrlIntegrationTest.java
@@ -116,7 +116,7 @@ class ShortUrlIntegrationTest {
                 .andExpect(status().isNotFound());
 
         mockMvc.perform(get("/api/v1/urls/" + nonExistentCode + "/stats"))
-                .andExpect(status().isOk());
+                .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 개요

  실패하는 2개 테스트 케이스를 수정하여 테스트 성공률을 97%에서 100%로 개선했습니다.

##  🔍 변경 내용

  🔧 핵심 로직 개선

  - GetStatsService: 통계 조회 전 URL 존재성 검증 추가
    - ShortUrlRepositoryPort를 통해 코드 존재 여부 확인
    - 존재하지 않는 코드에 대해 UrlNotFoundException 발생
    - URL 해결과 통계 조회 간 일관된 에러 처리 구현

  🧪 테스트 수정

  - ShortUrlControllerTest: Mock 설정을 실제 컨트롤러 동작에 맞게 수정
    - eq(null) → any(LocalDate.class) 매처로 변경
    - 컨트롤러의 기본값 처리 로직 반영
  - ShortUrlIntegrationTest: 존재하지 않는 코드의 통계 조회 응답 코드 수정
    - 200 OK → 404 Not Found로 변경하여 일관성 확보

  📊 개선 결과

  - 이전: 71개 테스트 중 69개 통과 (97% 성공률)
  - 현재: 71개 테스트 모두 통과 (100% 성공률) ✅

##  🗂 관련 이슈

  - 초기 분석에서 식별된 테스트 실패 문제 해결
  - 비즈니스 로직 일관성 개선

##  💡 테스트 방법

  1. 전체 테스트 실행: ./gradlew test
  2. 특정 컨트롤러 테스트: ./gradlew :api-server:test --tests "*ShortUrlControllerTest"
  3. 통합 테스트: ./gradlew :api-server:test --tests "*ShortUrlIntegrationTest"
  4. 존재하지 않는 코드로 통계 API 호출 시 404 응답 확인

##  🖼️ 스크린샷/로그

  테스트 결과 개선:
  - Before: 71 tests, 2 failures (97% success)
  - After: 71 tests, 0 failures (100% success)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음

- 버그 수정
  - 존재하지 않는 단축코드로 통계 조회 시 이제 404 Not Found를 반환하도록 수정하여 응답 일관성과 정확성을 향상했습니다.
  - 입력 검증을 강화해 잘못된 코드 요청에 대해 명확한 오류를 제공합니다. API 스키마나 응답 형식의 변경은 없습니다.

- 테스트
  - 통계 조회 관련 단위/통합 테스트를 새 동작(404 Not Found)에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->