### PR TITLE
[fix][BE] Redis 통계 데이터 조회 로직 수정

### DIFF
--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/persistence/CompositeStatisticsRepository.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/persistence/CompositeStatisticsRepository.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Repository
@@ -27,121 +28,89 @@ public class CompositeStatisticsRepository implements StatisticsRepository {
     
     @Override
     public List<DailyStatistics> getDailyStatistics(String code, LocalDate startDate, LocalDate endDate) {
-        // 먼저 Redis 캐시에서 통계 조회 시도
-        String cacheKey = "stats:" + code + ":" + startDate + ":" + endDate;
-        List<DailyStatistics> cachedStats = getCachedStatistics(cacheKey);
-        
-        if (cachedStats != null && !cachedStats.isEmpty()) {
-            return cachedStats;
-        }
-        
-        // 캐시 미스: 실시간으로 Redis 방문 키들을 조회해서 계산
-        List<DailyStatistics> result = calculateRealTimeStatistics(code, startDate, endDate);
-        
-        // 결과를 캐시에 저장 (5분 TTL)
-        cacheStatistics(cacheKey, result, 5, java.util.concurrent.TimeUnit.MINUTES);
-        
-        return result;
+        // batch-server가 만든 통계 캐시에서 조회
+        List<DailyStatistics> result = getBatchProcessedStatistics(code, startDate, endDate);
+
+        // 캐시가 없으면 빈 리스트 반환 (실시간 계산 안함)
+        return result != null ? result : new ArrayList<>();
     }
-    
-    private List<DailyStatistics> getCachedStatistics(String cacheKey) {
-        try {
-            Object cached = objectRedisTemplate.opsForValue().get(cacheKey);
-            if (cached != null) {
-                if (cached instanceof String jsonString) {
-                    return objectMapper.readValue(jsonString, new TypeReference<List<DailyStatistics>>() {});
-                } else if (cached instanceof List<?> list) {
-                    return objectMapper.convertValue(list, new TypeReference<List<DailyStatistics>>() {});
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Failed to retrieve cached statistics for key: {}", cacheKey, e);
-        }
-        return null;
-    }
-    
-    private List<DailyStatistics> calculateRealTimeStatistics(String code, LocalDate startDate, LocalDate endDate) {
+
+    /**
+     * batch-server가 처리한 통계 캐시를 조회합니다.
+     *
+     * <p>batch-server가 주기적으로 원시 방문 데이터를 집계해서 만든 통계 캐시를 조회합니다.
+     * "url:daily:stats:" 키 패턴으로 저장된 일별 통계를 날짜 범위에 따라 조회합니다.</p>
+     *
+     * @param code 단축 코드
+     * @param startDate 시작 날짜
+     * @param endDate 종료 날짜
+     * @return batch-server가 처리한 통계 리스트 (없으면 null)
+     */
+    private List<DailyStatistics> getBatchProcessedStatistics(String code, LocalDate startDate, LocalDate endDate) {
         List<DailyStatistics> result = new ArrayList<>();
         LocalDate currentDate = startDate;
-        
+
         while (!currentDate.isAfter(endDate)) {
-            long accessCount = getAccessCountForDate(code, currentDate);
-            
-            // 0이 아닌 경우만 결과에 포함
-            if (accessCount > 0) {
-                result.add(DailyStatistics.builder()
-                        .code(code)
-                        .date(currentDate)
-                        .accessCount(accessCount)
-                        .uniqueVisitors(estimateUniqueVisitors(accessCount))
-                        .build());
+            String dateKey = currentDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
+            String statsKey = "url:daily:stats:" + code + ":" + dateKey;
+
+            try {
+                Map<Object, Object> dailyStats = objectRedisTemplate.opsForHash().entries(statsKey);
+                if (dailyStats != null && !dailyStats.isEmpty()) {
+                    Long accessCount = getLongValue(dailyStats.get("accessCount"));
+                    Long uniqueVisitors = getLongValue(dailyStats.get("uniqueVisitors"));
+
+                    if (accessCount != null && accessCount > 0) {
+                        result.add(DailyStatistics.builder()
+                                .code(code)
+                                .date(currentDate)
+                                .accessCount(accessCount)
+                                .uniqueVisitors(uniqueVisitors != null ? uniqueVisitors : 0)
+                                .build());
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Failed to get batch processed statistics for key: {}", statsKey, e);
             }
-            
+
             currentDate = currentDate.plusDays(1);
         }
-        
-        return result;
+
+        return result.isEmpty() ? null : result;
     }
-    
-    private void cacheStatistics(String cacheKey, List<DailyStatistics> statistics, long timeout, java.util.concurrent.TimeUnit unit) {
+
+    /**
+     * Object 값을 Long으로 안전하게 변환합니다.
+     */
+    private Long getLongValue(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
         try {
-            String jsonValue = objectMapper.writeValueAsString(statistics);
-            objectRedisTemplate.opsForValue().set(cacheKey, jsonValue, timeout, unit);
-            log.debug("Cached statistics for key: {} with {} entries", cacheKey, statistics.size());
-        } catch (Exception e) {
-            log.warn("Failed to cache statistics for key: {}", cacheKey, e);
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
+
     
     @Override
     public long getAccessCountForDate(String code, LocalDate date) {
-        String pattern = "url:access:count:" + code + ":*";
-        String targetDatePrefix = date.format(DateTimeFormatter.ISO_LOCAL_DATE);
-        
-        ScanOptions scanOptions = ScanOptions.scanOptions()
-                .match(pattern)
-                .count(1000)
-                .build();
-        
-        long count = 0;
-        try (Cursor<String> cursor = stringRedisTemplate.scan(scanOptions)) {
-            while (cursor.hasNext()) {
-                String key = cursor.next();
-                if (key.contains(targetDatePrefix)) {
-                    count++;
-                }
+        // batch-server가 처리한 일별 통계에서 조회
+        String dateKey = date.format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String statsKey = "url:daily:stats:" + code + ":" + dateKey;
+
+        try {
+            Map<Object, Object> dailyStats = objectRedisTemplate.opsForHash().entries(statsKey);
+            if (dailyStats != null && !dailyStats.isEmpty()) {
+                Long accessCount = getLongValue(dailyStats.get("accessCount"));
+                return accessCount != null ? accessCount : 0;
             }
         } catch (Exception e) {
-            log.error("Failed to scan Redis keys for pattern: {} on date: {}", pattern, date, e);
-            return 0;
+            log.warn("Failed to get access count for date {} from batch statistics key: {}", date, statsKey, e);
         }
-        
-        return count;
-    }
-    
-    private long estimateUniqueVisitors(long accessCount) {
-        if (accessCount <= 0) {
-            return 0;
-        }
-        
-        // 현실적인 고유 방문자 추정 알고리즘:
-        // - 낮은 접근수: 고유 방문자 비율 높음 (90-95%)
-        // - 중간 접근수: 중간 비율 (70-80%)  
-        // - 높은 접근수: 중복 증가로 비율 감소 (50-70%)
-        
-        double uniqueRatio;
-        if (accessCount <= 10) {
-            // 1-10 접근: 거의 모두 고유 방문자
-            uniqueRatio = 0.95 - (accessCount - 1) * 0.02; // 95% -> 77%
-        } else if (accessCount <= 100) {
-            // 11-100 접근: 점진적 중복 증가
-            uniqueRatio = 0.77 - Math.log10(accessCount - 9) * 0.15; // 77% -> 62%
-        } else {
-            // 100+ 접근: 상당한 중복, 로그 스케일로 감소
-            uniqueRatio = 0.62 - Math.log10(accessCount / 100.0) * 0.1;
-            uniqueRatio = Math.max(uniqueRatio, 0.3); // 최소 30% 보장
-        }
-        
-        return Math.max(1, Math.round(accessCount * uniqueRatio));
+
+        return 0;
     }
 }

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
@@ -61,18 +61,22 @@ public class ResolveUrlService implements ResolveUrlUseCase {
     /**
      * 방문 기록을 Redis에 저장합니다.
      *
-     * <p>현재 시간을 기반으로 일별 카운터를 증가시키고 TTL을 설정하여 자동 정리합니다.
-     * 개별 타임스탬프 키 대신 일별 집계된 카운터를 사용하여 성능을 최적화합니다.</p>
+     * <p>현재 시간을 기반으로 타임스탬프 키를 생성하여 방문을 기록합니다.
+     * 각 방문은 개별 키로 저장되어 나중에 batch-server에서 통계 집계 시 활용됩니다.
+     * 키 존재 자체가 방문을 의미하므로 값은 상관없이 "1"로 설정합니다.</p>
      *
      * @param code 방문된 단축 코드
      */
     private void recordVisit(String code) {
         LocalDateTime now = LocalDateTime.now(clock);
-        String dayBucket = now.format(DateTimeFormatter.ISO_LOCAL_DATE);
-        String counterKey = "url:access:count:" + code + ":" + dayBucket;
+        String timestamp = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
 
-        // 일별 카운터 증가 및 TTL 설정 (설정 가능한 보관 기간)
-        redisTemplate.opsForValue().increment(counterKey);
-        redisTemplate.expire(counterKey, java.time.Duration.ofDays(properties.getVisitStatisticsTtlDays()));
+        // 개별 타임스탬프 키로 저장 (batch-server가 키 개수를 세어서 통계 생성)
+        String accessKey = "url:access:count:" + code + ":" + timestamp;
+
+        // 해당 키에 값을 설정 (값은 1로 고정, 키 존재 자체가 방문을 의미)
+        // TTL 설정으로 자동 정리 (batch-server가 처리할 수 있는 기간만큼 보관)
+        redisTemplate.opsForValue().set(accessKey, "1",
+            java.time.Duration.ofDays(properties.getVisitStatisticsTtlDays()));
     }
 }

--- a/BE/api-server/src/test/java/io/github/columnwise/shortlink/application/service/ResolveUrlServiceTest.java
+++ b/BE/api-server/src/test/java/io/github/columnwise/shortlink/application/service/ResolveUrlServiceTest.java
@@ -76,13 +76,11 @@ class ResolveUrlServiceTest {
         assertThat(result).isEqualTo(longUrl);
         verify(shortUrlRepository).findByCode(code);
         
-        // 방문 기록이 Redis에 저장되었는지 확인 (일별 카운터 증가 및 TTL 설정)
+        // 방문 기록이 Redis에 저장되었는지 확인 (개별 타임스탬프 키)
         verify(redisTemplate).opsForValue();
-        verify(valueOperations).increment(
-            argThat(key -> key.matches("url:access:count:" + code + ":\\d{4}-\\d{2}-\\d{2}"))
-        );
-        verify(redisTemplate).expire(
-            argThat(key -> key.matches("url:access:count:" + code + ":\\d{4}-\\d{2}-\\d{2}")),
+        verify(valueOperations).set(
+            argThat(key -> key.matches("url:access:count:" + code + ":\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}")),
+            eq("1"),
             eq(java.time.Duration.ofDays(90))
         );
     }

--- a/BE/batch-server/src/main/java/io/github/columnwise/shortlink/adapter/redis/RedisStatisticsReaderAdapter.java
+++ b/BE/batch-server/src/main/java/io/github/columnwise/shortlink/adapter/redis/RedisStatisticsReaderAdapter.java
@@ -25,18 +25,21 @@ public class RedisStatisticsReaderAdapter implements RedisStatisticsReader {
 
     @Override
     public Set<String> findAccessCountKeys(LocalDate date) {
+        // 개별 타임스탬프 키 패턴으로 스캔 (API 서버가 생성한 키들)
         String pattern = ACCESS_COUNT_KEY_PREFIX + "*";
         String targetDatePrefix = date.format(DateTimeFormatter.ISO_LOCAL_DATE);
-        
+
         ScanOptions scanOptions = ScanOptions.scanOptions()
                 .match(pattern)
                 .count(1000)
                 .build();
-        
+
         Set<String> matchingKeys = new HashSet<>();
         try (Cursor<String> cursor = redisTemplate.scan(scanOptions)) {
             while (cursor.hasNext()) {
                 String key = cursor.next();
+                // 키가 특정 날짜의 타임스탬프를 포함하는지 확인
+                // 예: url:access:count:abc123:2024-01-01T12:34:56
                 if (key.contains(targetDatePrefix)) {
                     matchingKeys.add(key);
                 }
@@ -45,7 +48,7 @@ public class RedisStatisticsReaderAdapter implements RedisStatisticsReader {
             log.error("Failed to scan access count keys for date: {}", date, e);
             return Collections.emptySet();
         }
-        
+
         log.debug("Found {} access count keys for date: {}", matchingKeys.size(), date);
         return matchingKeys;
     }


### PR DESCRIPTION
<!--
  📌 PR 제목 작성 규칙
  형식: [타입][영역] 한글 요약
  예시:
  [feat][BE] JWT 리프레시 토큰 로테이션
  [fix][FE] 차트 렌더링 오류 수정
  [feat][INFRA] RDS 서브넷 그룹 추가

  타입:
  feat    - 새로운 기능 추가
  fix     - 버그 수정
  refactor- 코드 리팩토링(기능 동일)
  docs    - 문서 수정
  chore   - 빌드/환경설정/패키지
  test    - 테스트 코드 관련
  perf    - 성능 개선
  -->

  ## 📌 PR 개요
  <!-- 어떤 작업을 했는지 한 줄로 요약 -->

  - Redis 통계 수집/조회 아키텍처 문제점 수정 및 올바른 데이터 플로우 구현

  ## 🔍 변경 내용
  <!-- 변경된 주요 사항과 이유를 간단히 작성 -->

  - **API 서버 방문 기록**: 일별 카운터 방식 → 개별 타임스탬프 키 방식으로 변경
  - **API 서버 통계 조회**: 실시간 Redis 키 스캔 로직 제거, batch-server 통계 캐시만 조회
  - **Batch 서버**: 기존 키 개수 카운팅 로직 유지 (정상 동작)
  - **데이터 플로우**: API 서버(원시 데이터 저장) → Batch 서버(통계 집계) → API 서버(통계 조회)
  구조 확립

  ## 🗂 관련 이슈
  <!-- Issue 번호를 적으면 자동 연결 (#번호) -->

  - Redis 통계 데이터 불일치 문제 해결
  - API 서버와 batch-server 간 역할 분리 명확화

  ## 💡 테스트 방법
  <!-- 직접 테스트하는 법을 구체적으로 작성 -->
  1. API 서버에서 단축 URL 리다이렉트 요청 (`GET /{code}`)
  2. Redis에서 `url:access:count:{code}:{timestamp}` 형태의 개별 키 생성 확인
  3. Batch 서버 실행하여 원시 데이터 집계 후 `url:daily:stats:` 키 생성 확인
  4. API 서버에서 통계 조회 (`GET /api/v1/stats/{code}`) 시 batch-server 처리 결과 반환 확인
  5. 모든 단위 테스트 통과 확인 (77/77 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 방문 데이터를 개별 타임스탬프 단위로 저장·만료 처리하여 일별 통계의 정확성과 확장성을 향상.
- 리팩터
  - 실시간 계산/캐시 경로를 배치 기반 일별 통계로 일원화하여 일관된 조회 제공.
- 버그 수정
  - 통계 데이터 부재 시 빈 목록을 안정적으로 반환해 오해를 줄임.
- 문서화
  - 키 스캔 방식과 형식에 대한 주석 보강.
- 테스트
  - 변경된 방문 기록 방식(타임스탬프 키, TTL)에 맞게 테스트 갱신.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->