### PR TITLE
[feat][BE] 안전한 URL 스킴만 허용하도록 검증 로직 추가

### DIFF
--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -32,3 +32,4 @@ out/
 
 ### Claude ###
 .claude/
+AGENTS.md

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/GlobalExceptionHandler.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package io.github.columnwise.shortlink.adapter.web;
 
 import io.github.columnwise.shortlink.domain.exception.UrlNotFoundException;
 import io.github.columnwise.shortlink.domain.exception.CodeCollisionException;
+import io.github.columnwise.shortlink.domain.exception.InvalidUriSchemeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -68,6 +69,21 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 유효하지 않은 URI 스킴 예외를 처리합니다.
+     *
+     * @param ex InvalidUriSchemeException 예외
+     * @return 400 Bad Request 응답
+     */
+    @ExceptionHandler(InvalidUriSchemeException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidUriSchemeException(InvalidUriSchemeException ex) {
+        log.warn("[400] Invalid URI scheme: {}", ex.getMessage());
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "INVALID_URI_SCHEME");
+        error.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
      * 요청 데이터 유효성 검증 실패 예외를 처리합니다.
      *
      * @param ex MethodArgumentNotValidException 예외
@@ -96,12 +112,7 @@ public class GlobalExceptionHandler {
         log.warn("[400] IllegalArgumentException: {}", ex.getMessage());
         Map<String, String> error = new HashMap<>();
         error.put("error", "BAD_REQUEST");
-        // 스킴 검증 오류인 경우 구체적인 메시지 제공
-        if (ex.getMessage() != null && ex.getMessage().contains("스킴")) {
-            error.put("message", ex.getMessage());
-        } else {
-            error.put("message", "Invalid request parameters");
-        }
+        error.put("message", "Invalid request parameters");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/GlobalExceptionHandler.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/GlobalExceptionHandler.java
@@ -93,10 +93,15 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
-        log.warn("[400] IllegalArgumentException", ex);
+        log.warn("[400] IllegalArgumentException: {}", ex.getMessage());
         Map<String, String> error = new HashMap<>();
         error.put("error", "BAD_REQUEST");
-        error.put("message", "Invalid request parameters");
+        // 스킴 검증 오류인 경우 구체적인 메시지 제공
+        if (ex.getMessage() != null && ex.getMessage().contains("스킴")) {
+            error.put("message", ex.getMessage());
+        } else {
+            error.put("message", "Invalid request parameters");
+        }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -8,6 +8,7 @@ import io.github.columnwise.shortlink.application.port.in.ResolveUrlUseCase;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.model.UrlMetrics;
 import io.github.columnwise.shortlink.util.ClientInfoExtractor;
+import io.github.columnwise.shortlink.util.UriSchemeValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
 
 
 /**
@@ -101,11 +103,15 @@ public class ShortUrlController {
 			description = "원본 URL로 리다이렉트 성공"
 		),
 		@ApiResponse(
+			responseCode = "400",
+			description = "유효하지 않은 URL 스킴 (HTTP/HTTPS만 허용)"
+		),
+		@ApiResponse(
 			responseCode = "404",
 			description = "존재하지 않는 단축 코드"
 		)
 	})
-	public RedirectView redirectToOriginalUrl(
+	public ResponseEntity<?> redirectToOriginalUrl(
 		@Parameter(description = "단축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
@@ -118,7 +124,16 @@ public class ShortUrlController {
 		String deviceType = ClientInfoExtractor.extractDeviceType(userAgent);
 
 		String longUrl = resolveUrlUseCase.resolveUrl(code, clientIp, browserFamily, deviceType);
-		return new RedirectView(longUrl);
+
+		// URI 스킴 검증 - 안전한 프로토콜만 허용
+		if (!UriSchemeValidator.isValidScheme(longUrl)) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.header(HttpHeaders.CONTENT_TYPE, "text/plain")
+					.body("Invalid URL scheme. Only HTTP and HTTPS are allowed.");
+		}
+
+		RedirectView redirectView = new RedirectView(longUrl);
+		return ResponseEntity.status(HttpStatus.FOUND).body(redirectView);
 	}
 
 	@GetMapping("/urls/{code}/metrics")

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -8,7 +8,6 @@ import io.github.columnwise.shortlink.application.port.in.ResolveUrlUseCase;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.model.UrlMetrics;
 import io.github.columnwise.shortlink.util.ClientInfoExtractor;
-import io.github.columnwise.shortlink.util.UriSchemeValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 
@@ -103,15 +101,11 @@ public class ShortUrlController {
 			description = "원본 URL로 리다이렉트 성공"
 		),
 		@ApiResponse(
-			responseCode = "400",
-			description = "유효하지 않은 URL 스킴 (HTTP/HTTPS만 허용)"
-		),
-		@ApiResponse(
 			responseCode = "404",
 			description = "존재하지 않는 단축 코드"
 		)
 	})
-	public Object redirectToOriginalUrl(
+	public ResponseEntity<Void> redirectToOriginalUrl(
 		@Parameter(description = "단축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
@@ -125,14 +119,9 @@ public class ShortUrlController {
 
 		String longUrl = resolveUrlUseCase.resolveUrl(code, clientIp, browserFamily, deviceType);
 
-		// URI 스킴 검증 - 안전한 프로토콜만 허용
-		if (!UriSchemeValidator.isValidScheme(longUrl)) {
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-					.header(HttpHeaders.CONTENT_TYPE, "text/plain")
-					.body("Invalid URL scheme. Only HTTP and HTTPS are allowed.");
-		}
-
-		return new RedirectView(longUrl);
+		return ResponseEntity.status(HttpStatus.FOUND)
+				.header(HttpHeaders.LOCATION, longUrl)
+				.build();
 	}
 
 	@GetMapping("/urls/{code}/metrics")

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -111,7 +111,7 @@ public class ShortUrlController {
 			description = "존재하지 않는 단축 코드"
 		)
 	})
-	public ResponseEntity<?> redirectToOriginalUrl(
+	public Object redirectToOriginalUrl(
 		@Parameter(description = "단축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
@@ -132,8 +132,7 @@ public class ShortUrlController {
 					.body("Invalid URL scheme. Only HTTP and HTTPS are allowed.");
 		}
 
-		RedirectView redirectView = new RedirectView(longUrl);
-		return ResponseEntity.status(HttpStatus.FOUND).body(redirectView);
+		return new RedirectView(longUrl);
 	}
 
 	@GetMapping("/urls/{code}/metrics")

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/CreateShortUrlService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/CreateShortUrlService.java
@@ -7,6 +7,7 @@ import io.github.columnwise.shortlink.domain.exception.CodeCollisionException;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.service.CodeGenerator;
 import io.github.columnwise.shortlink.util.HashUtils;
+import io.github.columnwise.shortlink.util.UriSchemeValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,11 @@ public class CreateShortUrlService implements CreateShortUrlUseCase {
     @Override
     @Transactional(readOnly = true)
     public ShortUrl createShortUrl(String longUrl) {
+
+        // URI 스킴 검증 - DB 저장 전에 수행
+        if (!UriSchemeValidator.isValidScheme(longUrl, properties.getAllowedSchemes())) {
+            throw new IllegalArgumentException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
+        }
 
         // 로깅용 URL 마스킹 처리
         // 보안상 민감할 수 있는 URL 정보를 마스킹하여 기록

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/CreateShortUrlService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/CreateShortUrlService.java
@@ -4,6 +4,7 @@ import io.github.columnwise.shortlink.application.port.in.CreateShortUrlUseCase;
 import io.github.columnwise.shortlink.application.port.out.ShortUrlRepositoryPort;
 import io.github.columnwise.shortlink.config.ShortUrlProperties;
 import io.github.columnwise.shortlink.domain.exception.CodeCollisionException;
+import io.github.columnwise.shortlink.domain.exception.InvalidUriSchemeException;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import io.github.columnwise.shortlink.domain.service.CodeGenerator;
 import io.github.columnwise.shortlink.util.HashUtils;
@@ -64,7 +65,7 @@ public class CreateShortUrlService implements CreateShortUrlUseCase {
 
         // URI 스킴 검증 - DB 저장 전에 수행
         if (!UriSchemeValidator.isValidScheme(longUrl, properties.getAllowedSchemes())) {
-            throw new IllegalArgumentException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
+            throw new InvalidUriSchemeException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
         }
 
         // 로깅용 URL 마스킹 처리

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
@@ -8,6 +8,7 @@ import io.github.columnwise.shortlink.util.HashUtils;
 import io.github.columnwise.shortlink.util.UriSchemeValidator;
 import org.springframework.data.redis.core.RedisTemplate;
 import io.github.columnwise.shortlink.domain.exception.UrlNotFoundException;
+import io.github.columnwise.shortlink.domain.exception.InvalidUriSchemeException;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
@@ -94,7 +95,7 @@ public class ResolveUrlService implements ResolveUrlUseCase {
 
         // URI 스킴 검증 - 통계 기록 전에 수행
         if (!UriSchemeValidator.isValidScheme(shortUrl.longUrl(), properties.getAllowedSchemes())) {
-            throw new UrlNotFoundException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
+            throw new InvalidUriSchemeException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
         }
 
         // 검증 통과한 경우에만 Redis에 타임스탬프 기반 방문 기록 저장

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/application/service/ResolveUrlService.java
@@ -5,6 +5,7 @@ import io.github.columnwise.shortlink.application.port.out.ShortUrlRepositoryPor
 import io.github.columnwise.shortlink.config.ShortUrlProperties;
 import io.github.columnwise.shortlink.domain.service.RedisKeyManager;
 import io.github.columnwise.shortlink.util.HashUtils;
+import io.github.columnwise.shortlink.util.UriSchemeValidator;
 import org.springframework.data.redis.core.RedisTemplate;
 import io.github.columnwise.shortlink.domain.exception.UrlNotFoundException;
 import io.github.columnwise.shortlink.domain.model.ShortUrl;
@@ -90,10 +91,15 @@ public class ResolveUrlService implements ResolveUrlUseCase {
     public String resolveUrl(String code, String ip, String uaFamily, String deviceType) {
         ShortUrl shortUrl = shortUrlRepository.findByCode(code)
                 .orElseThrow(() -> new UrlNotFoundException("URL not found for code: " + code));
-        
-        // Redis에 타임스탬프 기반 방문 기록 저장
+
+        // URI 스킴 검증 - 통계 기록 전에 수행
+        if (!UriSchemeValidator.isValidScheme(shortUrl.longUrl(), properties.getAllowedSchemes())) {
+            throw new UrlNotFoundException("유효하지 않은 URL 스킴입니다. 허용되는 스킴: " + properties.getAllowedSchemes());
+        }
+
+        // 검증 통과한 경우에만 Redis에 타임스탬프 기반 방문 기록 저장
         recordVisit(code, ip, uaFamily, deviceType);
-        
+
         return shortUrl.longUrl();
     }
     

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/config/ShortUrlProperties.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/config/ShortUrlProperties.java
@@ -16,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
  * <pre>
  * app.shorturl.max-retries=5
  * app.shorturl.default-expiration-days=365
+ * app.shorturl.allowed-schemes=http,https,mailto
  * </pre>
  *
  * <p>모든 설정값은 Bean Validation을 통해 검증됩니다.</p>
@@ -50,4 +51,12 @@ public class ShortUrlProperties {
      */
     @Positive(message = "visitStatisticsTtlDays must be positive")
     private long visitStatisticsTtlDays = 2;
+
+    /**
+     * 허용되는 URL 스킴 목록
+     *
+     * <p>리다이렉트 시 허용할 URL 스킴들의 목록입니다.
+     * 보안상 안전한 스킴만 포함해야 합니다.</p>
+     */
+    private java.util.Set<String> allowedSchemes = java.util.Set.of("http", "https", "mailto");
 }

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
@@ -12,22 +12,14 @@ import java.util.Set;
  * <p>리다이렉트 전에 URL의 스킴을 검증하여 안전한 프로토콜만 허용합니다.
  * 악성 스킴(javascript:, data:, file: 등)을 차단하여 보안을 강화합니다.</p>
  *
- * <p>허용되는 안전한 스킴:</p>
- * <ul>
- *   <li>http</li>
- *   <li>https</li>
- * </ul>
+ * <p>허용되는 스킴은 ShortUrlProperties 설정을 통해 관리됩니다.</p>
  */
 @Slf4j
 public class UriSchemeValidator {
 
-    /**
-     * 허용되는 안전한 URI 스킴 목록
-     */
-    private static final Set<String> ALLOWED_SCHEMES = Set.of(
-            "http",
-            "https"
-    );
+    private UriSchemeValidator() {
+        // Utility class - prevent instantiation
+    }
 
     /**
      * 차단해야 할 위험한 URI 스킴 목록 (로깅용)
@@ -53,9 +45,10 @@ public class UriSchemeValidator {
      * URI의 스킴이 안전한지 검증합니다.
      *
      * @param url 검증할 URL
+     * @param allowedSchemes 허용되는 스킴 목록
      * @return 안전한 스킴이면 true, 그렇지 않으면 false
      */
-    public static boolean isValidScheme(String url) {
+    public static boolean isValidScheme(String url, Set<String> allowedSchemes) {
         if (url == null || url.isBlank()) {
             log.warn("Empty or null URL provided for scheme validation");
             return false;
@@ -79,7 +72,7 @@ public class UriSchemeValidator {
             }
 
             // 허용된 스킴 체크
-            boolean isAllowed = ALLOWED_SCHEMES.contains(lowerScheme);
+            boolean isAllowed = allowedSchemes.contains(lowerScheme);
 
             if (!isAllowed) {
                 log.warn("Unknown or disallowed scheme: {} in URL: {}", lowerScheme, url);
@@ -93,12 +86,4 @@ public class UriSchemeValidator {
         }
     }
 
-    /**
-     * 허용되는 스킴 목록을 반환합니다.
-     *
-     * @return 허용되는 스킴의 불변 집합
-     */
-    public static Set<String> getAllowedSchemes() {
-        return ALLOWED_SCHEMES;
-    }
 }

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
@@ -1,0 +1,104 @@
+package io.github.columnwise.shortlink.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+/**
+ * URI 스킴 검증 유틸리티
+ *
+ * <p>리다이렉트 전에 URL의 스킴을 검증하여 안전한 프로토콜만 허용합니다.
+ * 악성 스킴(javascript:, data:, file: 등)을 차단하여 보안을 강화합니다.</p>
+ *
+ * <p>허용되는 안전한 스킴:</p>
+ * <ul>
+ *   <li>http</li>
+ *   <li>https</li>
+ * </ul>
+ */
+@Slf4j
+public class UriSchemeValidator {
+
+    /**
+     * 허용되는 안전한 URI 스킴 목록
+     */
+    private static final Set<String> ALLOWED_SCHEMES = Set.of(
+            "http",
+            "https"
+    );
+
+    /**
+     * 차단해야 할 위험한 URI 스킴 목록 (로깅용)
+     */
+    private static final Set<String> DANGEROUS_SCHEMES = Set.of(
+            "javascript",
+            "data",
+            "file",
+            "vbscript",
+            "about",
+            "chrome",
+            "chrome-extension",
+            "ms-appx",
+            "ms-appx-web",
+            "ftp",
+            "sftp",
+            "mailto",
+            "tel",
+            "sms"
+    );
+
+    /**
+     * URI의 스킴이 안전한지 검증합니다.
+     *
+     * @param url 검증할 URL
+     * @return 안전한 스킴이면 true, 그렇지 않으면 false
+     */
+    public static boolean isValidScheme(String url) {
+        if (url == null || url.isBlank()) {
+            log.warn("Empty or null URL provided for scheme validation");
+            return false;
+        }
+
+        try {
+            URI uri = new URI(url);
+            String scheme = uri.getScheme();
+
+            if (scheme == null) {
+                log.warn("URL without scheme: {}", url);
+                return false;
+            }
+
+            String lowerScheme = scheme.toLowerCase();
+
+            // 위험한 스킴 체크 및 로깅
+            if (DANGEROUS_SCHEMES.contains(lowerScheme)) {
+                log.warn("Dangerous scheme detected and blocked: {} in URL: {}", lowerScheme, url);
+                return false;
+            }
+
+            // 허용된 스킴 체크
+            boolean isAllowed = ALLOWED_SCHEMES.contains(lowerScheme);
+
+            if (!isAllowed) {
+                log.warn("Unknown or disallowed scheme: {} in URL: {}", lowerScheme, url);
+            }
+
+            return isAllowed;
+
+        } catch (URISyntaxException e) {
+            log.warn("Invalid URI syntax: {} - {}", url, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 허용되는 스킴 목록을 반환합니다.
+     *
+     * @return 허용되는 스킴의 불변 집합
+     */
+    public static Set<String> getAllowedSchemes() {
+        return ALLOWED_SCHEMES;
+    }
+}

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/util/UriSchemeValidator.java
@@ -23,6 +23,7 @@ public class UriSchemeValidator {
 
     /**
      * 차단해야 할 위험한 URI 스킴 목록 (로깅용)
+     * 주로 XSS, CSRF, 로컬 파일 접근 등의 보안 위험이 있는 스킴들
      */
     private static final Set<String> DANGEROUS_SCHEMES = Set.of(
             "javascript",
@@ -33,12 +34,7 @@ public class UriSchemeValidator {
             "chrome",
             "chrome-extension",
             "ms-appx",
-            "ms-appx-web",
-            "ftp",
-            "sftp",
-            "mailto",
-            "tel",
-            "sms"
+            "ms-appx-web"
     );
 
     /**

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "BE",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/BE/shared/src/main/java/io/github/columnwise/shortlink/domain/exception/InvalidUriSchemeException.java
+++ b/BE/shared/src/main/java/io/github/columnwise/shortlink/domain/exception/InvalidUriSchemeException.java
@@ -1,0 +1,18 @@
+package io.github.columnwise.shortlink.domain.exception;
+
+/**
+ * 유효하지 않은 URI 스킴 예외
+ *
+ * <p>허용되지 않은 스킴(javascript:, data: 등)을 가진 URL에 대해 발생하는 예외입니다.</p>
+ * <p>보안상 위험하거나 정책적으로 허용되지 않는 URI 스킴을 사용할 때 던져집니다.</p>
+ */
+public class InvalidUriSchemeException extends RuntimeException {
+
+    public InvalidUriSchemeException(String message) {
+        super(message);
+    }
+
+    public InvalidUriSchemeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
  ## 📌 PR 개요
  리다이렉트 시 안전한 URL 스킴만 허용하도록 검증 로직을 추가하여 보안을 강화합니다.

  ## 🔍 변경 내용
  - UriSchemeValidator 유틸리티 클래스 추가로 URL 스킴 검증 기능 구현
  - HTTP, HTTPS, mailto 스킴만 허용하고 javascript:, data:, file: 등 위험한 스킴 차단
  - 설정 가능한 URL 스킴 정책 - ShortUrlProperties에서 허용 스킴 관리
  - URL 생성 시점과 해석 시점 모두에서 스킴 검증 수행
  - InvalidUriSchemeException 전용 예외 클래스 추가
  - 표준 HTTP 리다이렉트 방식(Location 헤더) 적용
  - 유효하지 않은 스킴에 대해 400 Bad Request와 구체적인 에러 메시지 반환
  - AGENTS.md를 .gitignore에 추가

  ## 🗂 관련 이슈
  closes #61

  ## 💡 테스트 방법
  1. 단축 URL 생성 시 javascript: 등 위험한 스킴으로 요청 → 400 에러와 "INVALID_URI_SCHEME" 메시지 확인
  2. 기존에 저장된 URL을 악의적인 스킴으로 DB에서 직접 변경 후 해당 단축 코드 접근 → 400 에러 확인
  3. HTTP/HTTPS/mailto URL은 정상 생성 및 리다이렉트 확인
  4. 설정 변경을 통한 허용 스킴 조정 가능 확인

  ## 🖼️ 스크린샷/로그 (선택)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 허용 가능한 URL 스킴을 설정 가능(기본: http, https, mailto).
  - 리디렉션 응답이 Location 헤더로 일관되게 반환됩니다.

- **버그 수정 / 보안**
  - 위험하거나 허용되지 않는 URL 스킴을 사전 검사해 차단합니다.
  - 유효하지 않은 스킴 대상에 대해서는 요청을 400 응답으로 처리하고 방문 기록을 남기지 않습니다.
  - 잘못된 스킴 오류에 대해 더 설명적인 메시지를 제공합니다.

- **기타**
  - .gitignore에 AGENTS.md 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->