### PR TITLE
[fix][INFRA] Docker 빌드 컨텍스트 경로 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: shortlink-api
           IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./BE/api-server
+        working-directory: ./BE
         run: |
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .
+          docker build -f api-server/Dockerfile -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .
           docker tag "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
@@ -96,9 +96,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: shortlink-events-consumer
           IMAGE_TAG: ${{ github.sha }}
-        working-directory: ./BE/events-consumer
+        working-directory: ./BE
         run: |
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .
+          docker build -f events-consumer/Dockerfile -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .
           docker tag "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"


### PR DESCRIPTION
  ## 📌 PR 개요
  Docker 빌드 시 멀티모듈 구조 경로 오류 수정

  ## 🔍 변경 내용

  ### Docker 빌드 컨텍스트 경로 수정
  - **문제**: GitHub Actions에서 `working-directory: ./BE/api-server`로 설정했으나, Dockerfile은 `COPY
  api-server/src ...` 형태로 상위 경로를 참조
  - **원인**: Dockerfile이 멀티모듈 구조를 가정하고 BE 디렉토리를 루트로 예상
  - **해결**:
    - `working-directory`를 `./BE/api-server` → `./BE`로 변경
    - `docker build` 명령에 `-f api-server/Dockerfile` 플래그 추가
    - events-consumer도 동일하게 수정

  ### 변경 전
  ```yaml
  working-directory: ./BE/api-server
  run: |
    docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .

  변경 후

  working-directory: ./BE
  run: |
    docker build -f api-server/Dockerfile -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}" .

  🗂 관련 이슈


  💡 테스트 방법

  1. GitHub Actions CI 확인

  ✓ Build and Test 성공
  ✓ Build and push API Server image 성공
  ✓ Build and push Events Consumer image 성공

  2. ECR 이미지 확인

  # ECR 로그인 후 이미지 확인
  aws ecr describe-images --repository-name shortlink-api --region ap-northeast-2
  aws ecr describe-images --repository-name shortlink-events-consumer --region ap-northeast-2

  3. 로컬 빌드 테스트 (선택)

  cd BE
  docker build -f api-server/Dockerfile -t test-api .
  docker build -f events-consumer/Dockerfile -t test-consumer .

  🖼️ 스크린샷/로그

  이전 에러 로그:
  ERROR: failed to build: failed to solve: failed to compute cache key:
  failed to calculate checksum: "/api-server/src": not found

  수정 후 예상 결과:
  ✅ Successfully built and pushed:
  - shortlink-api:758e74b
  - shortlink-events-consumer:758e74b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 빌드 프로세스 최적화로 이루어졌습니다. 최종 사용자에게 직접적인 영향을 미치는 변경 사항은 없습니다. 서비스의 기능, 성능, 또는 사용자 환경에는 변함이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->