### PR TITLE
[fix][BE] 요청 헤더 기반 short URL 생성으로 localhost 반환 문제 수정

### DIFF
--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -1,4 +1,4 @@
-﻿package io.github.columnwise.shortlink.adapter.web;
+package io.github.columnwise.shortlink.adapter.web;
 
 import io.github.columnwise.shortlink.adapter.web.dto.CreateShortUrlRequest;
 import io.github.columnwise.shortlink.adapter.web.dto.CreateShortUrlResponse;
@@ -33,24 +33,24 @@ import org.springframework.http.HttpHeaders;
 
 
 /**
- * URL ?�축 ?�비??REST API 컴트롤러
+ * URL 단축 서비스 REST API 컨트롤러
  *
- * <p>URL ?�축 ?�비?�의 주요 기능??REST API�??�공?�는 컴트롤러?�니??
- * Hexagonal Architecture?�서 Web Adapter ??��???�당?�며, ?��? HTTP ?�청???�메???�비?�로 ?�달?�니??</p>
+ * <p>URL 단축 서비스의 주요 기능을 REST API로 제공하는 컨트롤러입니다.
+ * Hexagonal Architecture에서 Web Adapter 역할을 담당하며, 외부 HTTP 요청을 도메인 서비스로 전달합니다.</p>
  *
- * <p>?�공 기능:</p>
+ * <p>제공 기능:</p>
  * <ul>
- *   <li>URL ?�축 ?�성 (POST /api/v1/urls)</li>
- *   <li>URL 리다?�렉??(GET /api/v1/r/{code})</li>
- *   <li>?�별 ?�속 ?�계 조회 (GET /api/v1/urls/{code}/stats)</li>
+ *   <li>URL 단축 생성 (POST /api/v1/urls)</li>
+ *   <li>URL 리다이렉트 (GET /api/v1/r/{code})</li>
+ *   <li>개별 접속 통계 조회 (GET /api/v1/urls/{code}/stats)</li>
  * </ul>
  *
- * <p>OpenAPI/Swagger 문서?��? 지?�하�? Bean Validation???�한 ?�력 검증을 ?�행?�니??</p>
+ * <p>OpenAPI/Swagger 문서화를 지원하며, Bean Validation을 통한 입력 검증을 수행합니다.</p>
  */
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "Short URL API", description = "URL ?�축 ?�비??REST API")
+@Tag(name = "Short URL API", description = "URL 단축 서비스 REST API")
 public class ShortUrlController {
 
 	private final CreateShortUrlUseCase createShortUrlUseCase;
@@ -60,22 +60,22 @@ public class ShortUrlController {
 	@Value("${server.url}")
 	private String serverUrl;
 
-    
+
 
 	@PostMapping("/urls")
 	@Operation(
-		summary = "URL ?�축",
-		description = "�?URL???�축 코드�?변?�합?�다."
+		summary = "URL 단축",
+		description = "긴 URL을 단축 코드로 변환합니다."
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "201",
-			description = "URL ?�축 ?�공",
+			description = "URL 단축 성공",
 			content = @Content(schema = @Schema(implementation = CreateShortUrlResponse.class))
 		),
 		@ApiResponse(
 			responseCode = "400",
-			description = "?�못???�청 (?�효?��? ?��? URL ?�식)"
+			description = "잘못된 요청 (유효하지 않은 URL 형식)"
 		)
 	})
     public ResponseEntity<CreateShortUrlResponse> createShortUrl(
@@ -140,20 +140,20 @@ public class ShortUrlController {
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "302",
-			description = "?�본 URL�?리다?�렉???�공"
+			description = "원본 URL로 리다이렉트 성공"
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재?��? ?�는 ?�축 코드"
+			description = "존재하지 않는 단축 코드"
 		)
 	})
 	public ResponseEntity<Void> redirectToOriginalUrl(
-		@Parameter(description = "?�축 코드", required = true, example = "abc123")
+		@Parameter(description = "단축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
 	) {
-		// 로드밸런???�경??고려???�라?�언???�보 추출
-		// todo IP 주소 ?�식 검�? user-agent 길이 ?�한
+		// 로드밸런서 환경을 고려한 클라이언트 정보 추출
+		// todo IP 주소 형식 검증, user-agent 길이 제한
 		String clientIp = ClientInfoExtractor.getClientIp(request);
 		String userAgent = request.getHeader("User-Agent");
 		String browserFamily = ClientInfoExtractor.extractBrowserFamily(userAgent);
@@ -168,22 +168,22 @@ public class ShortUrlController {
 
 	@GetMapping("/urls/{code}/metrics")
 	@Operation(
-		summary = "URL ?�적 ?�계 조회",
-		description = "?�정 ?�축 URL???�적 ?�계 ?�보�?조회?�니?? �?조회?? ?�늘 조회???�의 ?�약 ?�보�??�공?�니??"
+		summary = "URL 접적 통계 조회",
+		description = "특정 단축 URL의 접적 통계 정보를 조회합니다. 총 조회수, 오늘 조회수 등의 요약 정보를 제공합니다."
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "200",
-			description = "?�계 조회 ?�공",
+			description = "통계 조회 성공",
 			content = @Content(schema = @Schema(implementation = UrlMetrics.class))
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재?��? ?�는 ?�축 코드"
+			description = "존재하지 않는 단축 코드"
 		)
 	})
 	public ResponseEntity<UrlMetrics> getUrlMetrics(
-		@Parameter(description = "?�축 코드", required = true, example = "abc123")
+		@Parameter(description = "단축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code
 	) {
 		UrlMetrics metrics = getStatsUseCase.getUrlMetrics(code);

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -1,4 +1,4 @@
-package io.github.columnwise.shortlink.adapter.web;
+﻿package io.github.columnwise.shortlink.adapter.web;
 
 import io.github.columnwise.shortlink.adapter.web.dto.CreateShortUrlRequest;
 import io.github.columnwise.shortlink.adapter.web.dto.CreateShortUrlResponse;
@@ -30,28 +30,27 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.beans.factory.annotation.Autowired;
 
 
 /**
- * URL ?�축 ?�비??REST API 컴트롤러
+ * URL ?�축 ?�비??REST API 컴트롤러
  *
- * <p>URL ?�축 ?�비?�의 주요 기능??REST API�??�공?�는 컴트롤러?�니??
- * Hexagonal Architecture?�서 Web Adapter ??��???�당?�며, ?��? HTTP ?�청???�메???�비?�로 ?�달?�니??</p>
+ * <p>URL ?�축 ?�비?�의 주요 기능??REST API�??�공?�는 컴트롤러?�니??
+ * Hexagonal Architecture?�서 Web Adapter ??��???�당?�며, ?��? HTTP ?�청???�메???�비?�로 ?�달?�니??</p>
  *
- * <p>?�공 기능:</p>
+ * <p>?�공 기능:</p>
  * <ul>
- *   <li>URL ?�축 ?�성 (POST /api/v1/urls)</li>
- *   <li>URL 리다?�렉??(GET /api/v1/r/{code})</li>
- *   <li>?�별 ?�속 ?�계 조회 (GET /api/v1/urls/{code}/stats)</li>
+ *   <li>URL ?�축 ?�성 (POST /api/v1/urls)</li>
+ *   <li>URL 리다?�렉??(GET /api/v1/r/{code})</li>
+ *   <li>?�별 ?�속 ?�계 조회 (GET /api/v1/urls/{code}/stats)</li>
  * </ul>
  *
- * <p>OpenAPI/Swagger 문서?��? 지?�하�? Bean Validation???�한 ?�력 검증을 ?�행?�니??</p>
+ * <p>OpenAPI/Swagger 문서?��? 지?�하�? Bean Validation???�한 ?�력 검증을 ?�행?�니??</p>
  */
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "Short URL API", description = "URL ?�축 ?�비??REST API")
+@Tag(name = "Short URL API", description = "URL ?�축 ?�비??REST API")
 public class ShortUrlController {
 
 	private final CreateShortUrlUseCase createShortUrlUseCase;
@@ -61,29 +60,29 @@ public class ShortUrlController {
 	@Value("${server.url}")
 	private String serverUrl;
 
-	@Autowired
-	private HttpServletRequest httpRequest;
+    
 
 	@PostMapping("/urls")
 	@Operation(
-		summary = "URL ?�축",
-		description = "�?URL???�축 코드�?변?�합?�다."
+		summary = "URL ?�축",
+		description = "�?URL???�축 코드�?변?�합?�다."
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "201",
-			description = "URL ?�축 ?�공",
+			description = "URL ?�축 ?�공",
 			content = @Content(schema = @Schema(implementation = CreateShortUrlResponse.class))
 		),
 		@ApiResponse(
 			responseCode = "400",
-			description = "?�못???�청 (?�효?��? ?��? URL ?�식)"
+			description = "?�못???�청 (?�효?��? ?��? URL ?�식)"
 		)
 	})
-	public ResponseEntity<CreateShortUrlResponse> createShortUrl(
-		@Parameter(description = "?�축??URL ?�보", required = true)
-		@Valid @RequestBody CreateShortUrlRequest request
-	) {
+    public ResponseEntity<CreateShortUrlResponse> createShortUrl(
+        @Parameter(description = "축소할 URL 정보", required = true)
+        @Valid @RequestBody CreateShortUrlRequest request,
+        HttpServletRequest httpRequest
+    ) {
 		ShortUrl shortUrl = createShortUrlUseCase.createShortUrl(request.longUrl());
 
 
@@ -133,28 +132,28 @@ public class ShortUrlController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	@GetMapping("/r/{code}")
-	@Operation(
-		summary = "URL 리다?�렉??,
-		description = "?�축 코드�??�해 ?�본 URL�?리다?�렉?�합?�다."
-	)
+    @GetMapping("/r/{code}")
+    @Operation(
+        summary = "URL 리다이렉트",
+        description = "단축 코드로 원본 URL로 리다이렉트합니다."
+    )
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "302",
-			description = "?�본 URL�?리다?�렉???�공"
+			description = "?�본 URL�?리다?�렉???�공"
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재?��? ?�는 ?�축 코드"
+			description = "존재?��? ?�는 ?�축 코드"
 		)
 	})
 	public ResponseEntity<Void> redirectToOriginalUrl(
-		@Parameter(description = "?�축 코드", required = true, example = "abc123")
+		@Parameter(description = "?�축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
 	) {
-		// 로드밸런???�경??고려???�라?�언???�보 추출
-		// todo IP 주소 ?�식 검�? user-agent 길이 ?�한
+		// 로드밸런???�경??고려???�라?�언???�보 추출
+		// todo IP 주소 ?�식 검�? user-agent 길이 ?�한
 		String clientIp = ClientInfoExtractor.getClientIp(request);
 		String userAgent = request.getHeader("User-Agent");
 		String browserFamily = ClientInfoExtractor.extractBrowserFamily(userAgent);
@@ -169,25 +168,26 @@ public class ShortUrlController {
 
 	@GetMapping("/urls/{code}/metrics")
 	@Operation(
-		summary = "URL ?�적 ?�계 조회",
-		description = "?�정 ?�축 URL???�적 ?�계 ?�보�?조회?�니?? �?조회?? ?�늘 조회???�의 ?�약 ?�보�??�공?�니??"
+		summary = "URL ?�적 ?�계 조회",
+		description = "?�정 ?�축 URL???�적 ?�계 ?�보�?조회?�니?? �?조회?? ?�늘 조회???�의 ?�약 ?�보�??�공?�니??"
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "200",
-			description = "?�계 조회 ?�공",
+			description = "?�계 조회 ?�공",
 			content = @Content(schema = @Schema(implementation = UrlMetrics.class))
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재?��? ?�는 ?�축 코드"
+			description = "존재?��? ?�는 ?�축 코드"
 		)
 	})
 	public ResponseEntity<UrlMetrics> getUrlMetrics(
-		@Parameter(description = "?�축 코드", required = true, example = "abc123")
+		@Parameter(description = "?�축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code
 	) {
 		UrlMetrics metrics = getStatsUseCase.getUrlMetrics(code);
 		return ResponseEntity.ok(metrics);
 	}
 }
+

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -34,24 +34,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 
 /**
- * URL 단축 서비스 REST API 컴트롤러
+ * URL ?�축 ?�비??REST API 컴트롤러
  *
- * <p>URL 단축 서비스의 주요 기능을 REST API로 제공하는 컴트롤러입니다.
- * Hexagonal Architecture에서 Web Adapter 역할을 담당하며, 외부 HTTP 요청을 도메인 서비스로 전달합니다.</p>
+ * <p>URL ?�축 ?�비?�의 주요 기능??REST API�??�공?�는 컴트롤러?�니??
+ * Hexagonal Architecture?�서 Web Adapter ??��???�당?�며, ?��? HTTP ?�청???�메???�비?�로 ?�달?�니??</p>
  *
- * <p>제공 기능:</p>
+ * <p>?�공 기능:</p>
  * <ul>
- *   <li>URL 단축 생성 (POST /api/v1/urls)</li>
- *   <li>URL 리다이렉트 (GET /api/v1/r/{code})</li>
- *   <li>일별 접속 통계 조회 (GET /api/v1/urls/{code}/stats)</li>
+ *   <li>URL ?�축 ?�성 (POST /api/v1/urls)</li>
+ *   <li>URL 리다?�렉??(GET /api/v1/r/{code})</li>
+ *   <li>?�별 ?�속 ?�계 조회 (GET /api/v1/urls/{code}/stats)</li>
  * </ul>
  *
- * <p>OpenAPI/Swagger 문서화를 지원하며, Bean Validation을 통한 입력 검증을 수행합니다.</p>
+ * <p>OpenAPI/Swagger 문서?��? 지?�하�? Bean Validation???�한 ?�력 검증을 ?�행?�니??</p>
  */
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "Short URL API", description = "URL 단축 서비스 REST API")
+@Tag(name = "Short URL API", description = "URL ?�축 ?�비??REST API")
 public class ShortUrlController {
 
 	private final CreateShortUrlUseCase createShortUrlUseCase;
@@ -66,22 +66,22 @@ public class ShortUrlController {
 
 	@PostMapping("/urls")
 	@Operation(
-		summary = "URL 단축",
-		description = "긴 URL을 단축 코드로 변환합니다."
+		summary = "URL ?�축",
+		description = "�?URL???�축 코드�?변?�합?�다."
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "201",
-			description = "URL 단축 성공",
+			description = "URL ?�축 ?�공",
 			content = @Content(schema = @Schema(implementation = CreateShortUrlResponse.class))
 		),
 		@ApiResponse(
 			responseCode = "400",
-			description = "잘못된 요청 (유효하지 않은 URL 형식)"
+			description = "?�못???�청 (?�효?��? ?��? URL ?�식)"
 		)
 	})
 	public ResponseEntity<CreateShortUrlResponse> createShortUrl(
-		@Parameter(description = "단축할 URL 정보", required = true)
+		@Parameter(description = "?�축??URL ?�보", required = true)
 		@Valid @RequestBody CreateShortUrlRequest request
 	) {
 		ShortUrl shortUrl = createShortUrlUseCase.createShortUrl(request.longUrl());
@@ -92,13 +92,35 @@ public class ShortUrlController {
 			scheme = httpRequest.getScheme();
 		}
 
-		String host = httpRequest.getHeader("Host");
+		String host = httpRequest.getHeader("X-Forwarded-Host");
+		if (host == null || host.isBlank()) {
+			host = httpRequest.getHeader("Host");
+		}
 		if (host == null || host.isBlank()) {
 			String serverName = httpRequest.getServerName();
 			int port = httpRequest.getServerPort();
 			boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
 					|| ("https".equalsIgnoreCase(scheme) && port == 443);
 			host = defaultPort ? serverName : serverName + ":" + port;
+		}
+		// If multiple hosts forwarded, take the first
+		int commaIdx = host.indexOf(',');
+		if (commaIdx > 0) {
+			host = host.substring(0, commaIdx).trim();
+		}
+		// Append forwarded port if provided and non-default and host has no explicit port
+		if (!host.contains(":")) {
+			String fwdPort = httpRequest.getHeader("X-Forwarded-Port");
+			if (fwdPort != null && !fwdPort.isBlank()) {
+				try {
+					int p = Integer.parseInt(fwdPort.trim());
+					boolean defaultPort = ("http".equalsIgnoreCase(scheme) && p == 80)
+							|| ("https".equalsIgnoreCase(scheme) && p == 443);
+					if (!defaultPort) {
+						host = host + ":" + p;
+					}
+				} catch (NumberFormatException ignored) {}
+			}
 		}
 
 		String baseUrl = scheme + "://" + host;
@@ -113,26 +135,26 @@ public class ShortUrlController {
 
 	@GetMapping("/r/{code}")
 	@Operation(
-		summary = "URL 리다이렉트",
-		description = "단축 코드를 통해 원본 URL로 리다이렉트합니다."
+		summary = "URL 리다?�렉??,
+		description = "?�축 코드�??�해 ?�본 URL�?리다?�렉?�합?�다."
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "302",
-			description = "원본 URL로 리다이렉트 성공"
+			description = "?�본 URL�?리다?�렉???�공"
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재하지 않는 단축 코드"
+			description = "존재?��? ?�는 ?�축 코드"
 		)
 	})
 	public ResponseEntity<Void> redirectToOriginalUrl(
-		@Parameter(description = "단축 코드", required = true, example = "abc123")
+		@Parameter(description = "?�축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code,
 		HttpServletRequest request
 	) {
-		// 로드밸런서 환경을 고려한 클라이언트 정보 추출
-		// todo IP 주소 형식 검증, user-agent 길이 제한
+		// 로드밸런???�경??고려???�라?�언???�보 추출
+		// todo IP 주소 ?�식 검�? user-agent 길이 ?�한
 		String clientIp = ClientInfoExtractor.getClientIp(request);
 		String userAgent = request.getHeader("User-Agent");
 		String browserFamily = ClientInfoExtractor.extractBrowserFamily(userAgent);
@@ -147,22 +169,22 @@ public class ShortUrlController {
 
 	@GetMapping("/urls/{code}/metrics")
 	@Operation(
-		summary = "URL 누적 통계 조회",
-		description = "특정 단축 URL의 누적 통계 정보를 조회합니다. 총 조회수, 오늘 조회수 등의 요약 정보를 제공합니다."
+		summary = "URL ?�적 ?�계 조회",
+		description = "?�정 ?�축 URL???�적 ?�계 ?�보�?조회?�니?? �?조회?? ?�늘 조회???�의 ?�약 ?�보�??�공?�니??"
 	)
 	@ApiResponses({
 		@ApiResponse(
 			responseCode = "200",
-			description = "통계 조회 성공",
+			description = "?�계 조회 ?�공",
 			content = @Content(schema = @Schema(implementation = UrlMetrics.class))
 		),
 		@ApiResponse(
 			responseCode = "404",
-			description = "존재하지 않는 단축 코드"
+			description = "존재?��? ?�는 ?�축 코드"
 		)
 	})
 	public ResponseEntity<UrlMetrics> getUrlMetrics(
-		@Parameter(description = "단축 코드", required = true, example = "abc123")
+		@Parameter(description = "?�축 코드", required = true, example = "abc123")
 		@PathVariable("code") String code
 	) {
 		UrlMetrics metrics = getStatsUseCase.getUrlMetrics(code);

--- a/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
+++ b/BE/api-server/src/main/java/io/github/columnwise/shortlink/adapter/web/ShortUrlController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Autowired;
 
 
 /**
@@ -60,6 +61,9 @@ public class ShortUrlController {
 	@Value("${server.url}")
 	private String serverUrl;
 
+	@Autowired
+	private HttpServletRequest httpRequest;
+
 	@PostMapping("/urls")
 	@Operation(
 		summary = "URL 단축",
@@ -82,9 +86,26 @@ public class ShortUrlController {
 	) {
 		ShortUrl shortUrl = createShortUrlUseCase.createShortUrl(request.longUrl());
 
+
+		String scheme = httpRequest.getHeader("X-Forwarded-Proto");
+		if (scheme == null || scheme.isBlank()) {
+			scheme = httpRequest.getScheme();
+		}
+
+		String host = httpRequest.getHeader("Host");
+		if (host == null || host.isBlank()) {
+			String serverName = httpRequest.getServerName();
+			int port = httpRequest.getServerPort();
+			boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
+					|| ("https".equalsIgnoreCase(scheme) && port == 443);
+			host = defaultPort ? serverName : serverName + ":" + port;
+		}
+
+		String baseUrl = scheme + "://" + host;
+
 		CreateShortUrlResponse response = new CreateShortUrlResponse(
 				shortUrl.code(),
-				serverUrl + "/api/v1/r/" + shortUrl.code()
+				baseUrl + "/api/v1/r/" + shortUrl.code()
 		);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/BE/api-server/src/main/resources/application-dev.yaml
+++ b/BE/api-server/src/main/resources/application-dev.yaml
@@ -35,6 +35,7 @@ spring:
 server:
   url: ${SERVER_URL:http://localhost:8080}
   port: 8080
+  forward-headers-strategy: framework
 
 logging:
   level:

--- a/BE/api-server/src/main/resources/application.yaml
+++ b/BE/api-server/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
 
 server:
   url: ${SERVER_URL:http://localhost:8080}
+  forward-headers-strategy: framework
 
 management:
   endpoints:

--- a/BE/deploy/nginx/nginx.conf
+++ b/BE/deploy/nginx/nginx.conf
@@ -17,6 +17,7 @@ server {
     location / {
         proxy_pass http://api_backend;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
<!-- 
📌 PR 제목 작성 규칙
형식: [타입][영역] 한글 요약
예시:
[feat][BE] JWT 리프레시 토큰 로테이션
[fix][FE] 차트 렌더링 오류 수정
[feat][INFRA] RDS 서브넷 그룹 추가

타입:
feat    - 새로운 기능 추가
fix     - 버그 수정
refactor- 코드 리팩토링(기능 동일)
docs    - 문서 수정
chore   - 빌드/환경설정/패키지
test    - 테스트 코드 관련
perf    - 성능 개선
-->

## 📌 PR 개요
<!-- 어떤 작업을 했는지 한 줄로 요약 -->

- 프록시(Nginx) 뒤에서 POST /api/v1/urls 응답의 shortUrl이 localhost:8080으로 반환되던 문제를 해결했습니다. 요청의 헤
    더를 기반으로 base URL을 조립해 실제 접근 도메인을 반영합니다.

## 🔍 변경 내용
<!-- 변경된 주요 사항과 이유를 간단히 작성 -->

  - ShortUrlController
      - HttpServletRequest를 주입해 Host, X-Forwarded-Proto를 우선 사용하여 scheme://host를 도출합니다. 누락 시
        request.getScheme(), serverName[:port]로 폴백.
      - serverUrl + "/api/v1/r/{code}" → baseUrl + "/api/v1/r/{code}"로 변경.
  - Nginx 설정과의 정합성
      - 이미 proxy_set_header Host $host;, proxy_set_header X-Forwarded-Proto $scheme;가 설정되어 있어 본 변경으로 올바
        른 값이 사용됩니다.
  - 외부 API 스펙 변화 없음 (응답의 shortUrl 값이 실제 도메인으로 교정됨).

## 🗂 관련 이슈
<!-- Issue 번호를 적으면 자동 연결 (#번호) -->
-


## 💡 테스트 방법
  1. dev 환경 배포 후, POST /api/v1/urls로 단축 URL 생성.
  2. 응답의 shortUrl이 http(s)://<실제 호스트>/api/v1/r/{code} 형태인지 확인 (localhost 아님).
  3. 브라우저/HTTP 클라이언트로 shortUrl 접근 시 원본 URL로 302 리다이렉트 되는지 확인.
  4. 필요 시 HTTPS 환경에서도 X-Forwarded-Proto=https가 반영되는지 확인.

## 🖼️ 스크린샷/로그 (선택)
<!-- UI 변경 시 스크린샷 첨부, 서버 로깅/에러 메시지 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 프록시/로드밸런서 환경에서 단축 URL 생성 호환성 개선: 요청 전달 헤더(X-Forwarded-Proto/X-Forwarded-Host 등)를 기반으로 프로토콜·호스트·포트 정보를 동적으로 판단해 보다 정확한 리디렉션 URL을 생성합니다.
  * 다중 전달 호스트 처리 및 기본 포트 생략 로직을 추가해 잘못된 호스트/포트 포함 문제를 해소했습니다.

* **문서**
  * API 설명 문구(한국어)가 동적 베이스 URL 동작을 반영하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->